### PR TITLE
Add JSON property name for Screen in SimCtlDeviceType

### DIFF
--- a/AppleDev/SimCtl.cs
+++ b/AppleDev/SimCtl.cs
@@ -1183,7 +1183,7 @@ public class SimCtlDeviceType
 	[JsonPropertyName("devices")]
 	public List<SimCtlDevice> Devices { get; set; } = new List<SimCtlDevice>();
 
-	[JsonIgnore]
+	[JsonPropertyName("screen")]
 	public SimCtlScreenInfo? Screen { get; set; }
 }
 


### PR DESCRIPTION
Replaces [JsonIgnore] with [JsonPropertyName("screen")] for the Screen property in SimCtlDeviceType, enabling serialization and deserialization of screen information.